### PR TITLE
use get_max_ceil instead of get_max_floor

### DIFF
--- a/src/box_manager/_qt/SelectMetric.py
+++ b/src/box_manager/_qt/SelectMetric.py
@@ -1292,9 +1292,9 @@ class SelectMetricWidget(QWidget):
                 ):
                     val = label_data.loc[slice_idx, label_max]
                 else:
-                    val = general.get_max_floor(label_data[label_max])
+                    val = general.get_max_ceil(label_data[label_max])
                     if not np.all(val == label_data[label_max].dropna()):
-                        val = general.get_max_floor(features[col_name])
+                        val = general.get_max_ceil(features[col_name])
                 if not np.isnan(val):
                     output_dict[label_max] = str(val)
                 else:
@@ -1920,7 +1920,7 @@ class HistogramMinMaxView(QWidget):
         else:
             self._label_data = label_data
         val_min = general.get_min_floor(label_data.min())
-        val_max = general.get_max_floor(label_data.max())
+        val_max = general.get_max_ceil(label_data.max())
         val_min = val_min if not np.isnan(val_min) else 0
         val_max = val_max if not np.isnan(val_max) else 0
         self.slider_min.set_range(val_min, val_max)

--- a/src/box_manager/_utils/general.py
+++ b/src/box_manager/_utils/general.py
@@ -16,15 +16,15 @@ def get_min_floor(vals, step=1000):
         return np.nan
 
 
-def get_max_floor(vals, step=1000):
+def get_max_ceil(vals, step=1000):
     try:
         if isinstance(vals, pandas.Series):
             if pandas.isnull(vals).all():
                 return np.nan
             else:
-                return np.round(np.floor(np.nanmax(vals) * step) / step, 3)
+                return np.round(np.ceil(np.nanmax(vals) * step) / step, 3)
         else:
-            return np.round(np.floor(np.nanmax(vals) * step) / step, 3)
+            return np.round(np.ceil(np.nanmax(vals) * step) / step, 3)
     except ValueError:
         return np.nan
 

--- a/src/box_manager/io/tloc.py
+++ b/src/box_manager/io/tloc.py
@@ -125,7 +125,7 @@ def to_napari(
                     f"{entry}_{'min' if 'min' in func.__name__ else 'max'}": func(
                         idx_view_df[entry]
                     )
-                    for func in [general.get_min_floor, general.get_max_floor]
+                    for func in [general.get_min_floor, general.get_max_ceil]
                     for entry in _get_meta_idx()
                 }
             )


### PR DESCRIPTION
get_max_floor is used to set the maximum values for slides in selectmetric. I would rather use get_max_ceil here and refactored it accordingly. If we use get_max_floor, there are cases where it excludes particles with the the highest metric, which is not intuitive.