### PR TITLE
Fix crash when saving particle coordinates as cbox when working with tomograms

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.10
-  - napari>=0.4.18
+  - napari==0.4.17
   - pyqt
   - tifffile
   - numpy

--- a/src/box_manager/_tests/test_organizelayer.py
+++ b/src/box_manager/_tests/test_organizelayer.py
@@ -59,15 +59,26 @@ class Test__run_save:
         assert os.path.exists('/tmp/blub/tmp.cbox') == True
         shutil.rmtree('/tmp/blub/')
 
-    def test_save_tomo_particle(self, napari_viewer, organize_layer_widget_tomo):
+    def test_save_tomo_particle_cbox(self, napari_viewer, organize_layer_widget_tomo):
         # generate random tomogram
         organize_layer_widget_tomo._new_points()
         organize_layer_widget_tomo.save_layers['format'].setCurrentIndex(2) #cbox
         os.makedirs("/tmp/blub/", exist_ok=True)
-        points = [[77, 50, 50], [77, 100, 100], [77, 200, 200]]
+        points = [[77, 0, 0], [77, 100, 100], [77, 200, 200], [77, 300, 300]]
         napari_viewer.layers[1].add(points)
         organize_layer_widget_tomo._run_save()
         assert os.path.exists('/tmp/blub/tmp.cbox') == True
+        shutil.rmtree('/tmp/blub/')
+
+    def test_save_tomo_particle_coords(self, napari_viewer, organize_layer_widget_tomo):
+        # generate random tomogram
+        organize_layer_widget_tomo._new_points()
+        organize_layer_widget_tomo.save_layers['format'].setCurrentIndex(0) #coords
+        os.makedirs("/tmp/blub/", exist_ok=True)
+        points = [[77, 0, 0], [77, 100, 100], [77, 200, 200]]
+        napari_viewer.layers[1].add(points)
+        organize_layer_widget_tomo._run_save()
+        assert os.path.exists('/tmp/blub/tmp.coords') == True
         shutil.rmtree('/tmp/blub/')
 
     def test_save_stack_filament(self, napari_viewer, organize_layer_widget_stack):

--- a/src/box_manager/_tests/test_organizelayer.py
+++ b/src/box_manager/_tests/test_organizelayer.py
@@ -10,6 +10,9 @@ import tempfile
 import os
 import shutil
 
+from PyQt5.QtWidgets import QComboBox
+
+
 @pytest.fixture(scope="function")
 def napari_viewer():
     yield napari.Viewer()
@@ -24,7 +27,6 @@ def organize_layer_widget_tomo(napari_viewer):
         napari_viewer.open(plugin='napari-boxmanager',
                     path=f"{tmpdirname}/tmp.mrc")
         widget, _ = napari_viewer.window.add_plugin_dock_widget('napari-boxmanager', widget_name='organize_layer', tabify=True)
-        widget.widget()._new_shapes()
         yield widget.widget()
 
 @pytest.fixture(scope="function")
@@ -38,7 +40,6 @@ def organize_layer_widget_stack(napari_viewer):
         napari_viewer.open(plugin='napari-boxmanager',
                     path=[f"{tmpdirname}/tmp.mrc", f"{tmpdirname}/tmp_2.mrc"], stack=True)
         widget, _ = napari_viewer.window.add_plugin_dock_widget('napari-boxmanager', widget_name='organize_layer', tabify=True)
-        widget.widget()._new_shapes()
         yield widget.widget()
 
 @patch(
@@ -50,6 +51,7 @@ def organize_layer_widget_stack(napari_viewer):
 class Test__run_save:
     def test_save_tomo_filament(self, napari_viewer, organize_layer_widget_tomo):
         # generate random tomogram
+        organize_layer_widget_tomo._new_shapes()
         os.makedirs("/tmp/blub/", exist_ok=True)
         fila = [[77, 50, 50], [77, 100, 100], [77, 200, 200]]
         napari_viewer.layers[1]._add_shapes(fila, shape_type='path', edge_width=100)
@@ -57,8 +59,21 @@ class Test__run_save:
         assert os.path.exists('/tmp/blub/tmp.cbox') == True
         shutil.rmtree('/tmp/blub/')
 
+    def test_save_tomo_particle(self, napari_viewer, organize_layer_widget_tomo):
+        # generate random tomogram
+        organize_layer_widget_tomo._new_points()
+        organize_layer_widget_tomo.save_layers['format'].setCurrentIndex(2) #cbox
+        os.makedirs("/tmp/blub/", exist_ok=True)
+        points = [[77, 50, 50], [77, 100, 100], [77, 200, 200]]
+        napari_viewer.layers[1].add(points)
+        organize_layer_widget_tomo._run_save()
+        assert os.path.exists('/tmp/blub/tmp.cbox') == True
+        shutil.rmtree('/tmp/blub/')
+
     def test_save_stack_filament(self, napari_viewer, organize_layer_widget_stack):
         # generate random tomogram
+        organize_layer_widget_stack._new_shapes()
+
         os.makedirs("/tmp/blub/", exist_ok=True)
         fila = [[0, 50, 50], [0, 100, 100], [0, 200, 200]]
         napari_viewer.layers[1]._add_shapes(fila, shape_type='path', edge_width=100)

--- a/src/box_manager/io/io_utils.py
+++ b/src/box_manager/io/io_utils.py
@@ -473,7 +473,7 @@ def _write_particle_data(
 
     if "size" in meta:
         boxsize = meta["size"][mask]
-        boxsize = np.unique(boxsize, axis=1)
+        boxsize = np.median(boxsize, axis=1)
     else:
         # For filaments
         boxsize = np.array(meta["edge_width"])[mask]

--- a/src/box_manager/io/io_utils.py
+++ b/src/box_manager/io/io_utils.py
@@ -473,6 +473,7 @@ def _write_particle_data(
 
     if "size" in meta:
         boxsize = meta["size"][mask]
+        boxsize = np.unique(boxsize, axis=1)
     else:
         # For filaments
         boxsize = np.array(meta["edge_width"])[mask]


### PR DESCRIPTION
There was bug report on the mailing list:

https://listserv.gwdg.de/pipermail/sphire/2023-August/001180.html


I've added unit tests  that reproduce the problem and fixed it. @mstabrin please review it :-) 