### PR TITLE
Remove pyqt5 from deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,9 @@ install_requires =
     pystardb>=0.4.2
     napari>=0.4.17
     pandas
-    pyqt5
     scipy
     tifffile
     tqdm
-    PyQt5
 
 python_requires = >=3.10
 include_package_data = True


### PR DESCRIPTION
I think it is related to this issue:

https://github.com/napari/napari/issues/6415

When I remove it from the requirements, it works when I follow the cryolo installation instructions