### PR TITLE
Set is_3d consistently + fix not-masked feature dataframe

### DIFF
--- a/src/box_manager/_qt/OrganizeLayer.py
+++ b/src/box_manager/_qt/OrganizeLayer.py
@@ -579,7 +579,7 @@ class OrganizeLayerWidget(QWidget):
                 metadata[key]["image_name"] = value["name"]
                 metadata[key]["real"] = False
                 metadata[key]["write"] = None
-            elif key in ("original_path", "is_2d_stack"):
+            elif key in ("original_path", "is_2d_stack", "is_3d"):
                 metadata[key] = value
         return metadata
 

--- a/src/box_manager/io/io_utils.py
+++ b/src/box_manager/io/io_utils.py
@@ -334,6 +334,7 @@ def to_napari_coordinates(
     )
     metadata.update(orgbox_meta)
     metadata["is_2d_stack"] = is_2d_stack
+    metadata["is_3d"] = is_3d
     metadata["ignore_idx"] = feature_columns
 
     features = {}
@@ -489,6 +490,12 @@ def _write_particle_data(
     except KeyError:
         is_2d_stacked = False
 
+    try:
+        is_3d = meta["metadata"]["is_3d"]
+    except KeyError:
+        is_3d = False
+
+
     if is_2d_stacked:
         for z in meta["metadata"]:
             if not isinstance(z, int) or meta["metadata"][z]["write"] is False:
@@ -528,6 +535,8 @@ def _write_particle_data(
             if z in slices_with_coords:
                 continue
             empty_slices.append(z)
+        if not is_3d:
+            coordinates = coordinates[:,1:]
 
         export_data[output_file] = (
             format_func(

--- a/src/box_manager/io/io_utils.py
+++ b/src/box_manager/io/io_utils.py
@@ -477,6 +477,7 @@ def _write_particle_data(
         mask = np.ones(len(data), dtype=int) == 1
 
     coordinates = data[mask]
+    features = meta["features"].loc[mask, :]
 
     if "size" in meta:
         boxsize = meta["size"][mask]
@@ -513,7 +514,7 @@ def _write_particle_data(
             d = format_func(
                 coordinates=coordinates[mask, 1:],
                 box_size=boxsize[mask],
-                features=meta["features"].loc[mask, :],
+                features=features.loc[mask, :],
                 metadata=meta["metadata"],
                 filament_spacing=filament_spacing,
             )
@@ -542,7 +543,7 @@ def _write_particle_data(
             format_func(
                 coordinates=coordinates,
                 box_size=boxsize,
-                features=meta["features"].loc[mask, :],
+                features=features.loc[mask, :],
                 metadata=meta["metadata"],
                 filament_spacing=filament_spacing,
             ),


### PR DESCRIPTION
... otherwise, it will write a z coordinate if a single micrograph is loaded coordinates are saved.

Moreover, as soon as you apply a threshold, it crashes as the feature array was not masked with 'shown'